### PR TITLE
Use expanded path in `OPENSSL_DIR`

### DIFF
--- a/src/hosting/Uberspace/prosody.txt
+++ b/src/hosting/Uberspace/prosody.txt
@@ -72,7 +72,7 @@ Now we can install the needed modules [5]. If OpenSSL was updated using toast we
 luarocks install luasocket --local
 luarocks install luaexpat --local
 luarocks install luafilesystem --local
-luarocks install luasec 0.5.1 --local OPENSSL_DIR=~/.toast/armed/usr/local/
+luarocks install luasec 0.5.1 --local OPENSSL_DIR=$HOME/.toast/armed/usr/local/
 ====
 
 The modules should look like this now:


### PR DESCRIPTION
So far the guide passes an `OPENSSL_DIR` relative to `~`.
`luarocks` complains in this case that it cannot find `libssl`

```
$ luarocks install luasec 0.5.1 --local OPENSSL_DIR=~/.toast/armed/usr/local/
Installing http://www.luarocks.org/repositories/rocks/luasec-0.5.1-1.rockspec...
Using http://www.luarocks.org/repositories/rocks/luasec-0.5.1-1.rockspec... switching to 'build' mode

Error: Could not find expected file libssl.a, or libssl.so, or libssl.so.* for OPENSSL -- you may have to install OPENSSL in your system and/or pass OPENSSL_DIR or OPENSSL_LIBDIR to the luarocks command. Example: luarocks install luasec OPENSSL_DIR=/usr/local
```

despite the files being present:

```
$ ls ~/.toast/armed/usr/local/lib/libssl*
/home/<user>/.toast/armed/usr/local/lib/libssl.a
/home/<user>/.toast/armed/usr/local/lib/libssl.so
/home/<user>/.toast/armed/usr/local/lib/libssl.so.1
/home/<user>/.toast/armed/usr/local/lib/libssl.so.1.0.0
```

Therefore this commit recommends passing an expanded path:

```
$ luarocks install luasec 0.5.1 --local OPENSSL_DIR=$HOME/.toast/armed/usr/local/
   [...]
luasec 0.5.1-1 is now built and installed in /home/<user>/.luarocks (license: MIT)
```